### PR TITLE
Normalize point cloud units and header offsets

### DIFF
--- a/README
+++ b/README
@@ -23,6 +23,10 @@ pip install -r requirements.txt
 **Note:**
 LAZ compression is supported out-of-the-box via the `laszip` backend, which is included in `requirements.txt`. No extra steps are needed.
 
+### Coordinate units
+
+The converter assumes the input point cloud coordinates are expressed in **millimeters**. They are converted to meters before writing the LAZ files, which use a scale factor of `0.0001` m and zero offsets to match the Mandeye recorder. Make sure your source data uses the same convention to avoid unit mismatches.
+
 ## Usage
 
 ```sh

--- a/bag2mandeye.py
+++ b/bag2mandeye.py
@@ -120,15 +120,19 @@ def save_data(
 
     written_lidar_path = None
     if points:
-        xs = np.array([p.x for p in points], dtype=np.float64)
-        ys = np.array([p.y for p in points], dtype=np.float64)
-        zs = np.array([p.z for p in points], dtype=np.float64)
+        # Mandeye recorder stores coordinates in meters with 0.1 mm resolution.
+        # PointCloud2 data in ROS bags may be in millimeters, so convert to meters
+        # to avoid unit mismatches.
+        xs = np.array([p.x for p in points], dtype=np.float64) * 0.001
+        ys = np.array([p.y for p in points], dtype=np.float64) * 0.001
+        zs = np.array([p.z for p in points], dtype=np.float64) * 0.001
         intensities = np.array([p.intensity for p in points], dtype=np.float32)
         times = np.array([p.timestamp for p in points], dtype=np.float64) / 1e9
 
         header = laspy.LasHeader(point_format=1, version="1.2")
         header.scales = [0.0001, 0.0001, 0.0001]
-        header.offsets = [float(xs.min()), float(ys.min()), float(zs.min())]
+        # Mandeye recorder uses unoffset coordinates
+        header.offsets = [0.0, 0.0, 0.0]
 
         las = laspy.LasData(header)
         las.x = xs


### PR DESCRIPTION
## Summary
- convert millimeter point coordinates to meters in LAZ writer
- match Mandeye recorder's 0.0001 m scale and zero offsets
- document coordinate unit assumption in README

## Testing
- `python -m py_compile bag2mandeye.py`
- `python bag2mandeye.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68bdd6c5ac1c832aadf056d0377eca13