### PR TITLE
Add relative IMU timestamp option

### DIFF
--- a/README
+++ b/README
@@ -59,6 +59,7 @@ python bag2mandeye.py mybag /tmp/out \
 - `--emulate_point_ts`: Interpolate timestamps for points (default: False)
 - `--lidar_sn`: Lidar serial number for `.sn` file (default: `ABC123`)
 - `--lidar_id`: Lidar id for `.sn` file (default: `0`)
+- `--absolute_imu_ts`: Use absolute IMU timestamps instead of starting at zero (default: False)
 
 ## Output
 


### PR DESCRIPTION
## Summary
- Track starting IMU nanoseconds and compute relative timestamps for IMU lines
- Keep original nanoseconds for timestampUnix while allowing absolute timestamps via `--absolute_imu_ts`
- Document new `--absolute_imu_ts` CLI option

## Testing
- `python bag2mandeye.py --help`
- `python -m py_compile bag2mandeye.py`


------
https://chatgpt.com/codex/tasks/task_e_68c32bb12e04832a8451208d9fd4e081