### PR TITLE
Add input unit option for Mandeye converter

### DIFF
--- a/README
+++ b/README
@@ -25,7 +25,7 @@ LAZ compression is supported out-of-the-box via the `laszip` backend, which is i
 
 ### Coordinate units
 
-The converter assumes the input point cloud coordinates are expressed in **millimeters**. They are converted to meters before writing the LAZ files, which use a scale factor of `0.0001` m and zero offsets to match the Mandeye recorder. Make sure your source data uses the same convention to avoid unit mismatches.
+By default the converter assumes the input point cloud coordinates are expressed in **millimeters** and converts them to meters before writing the LAZ files, which use a scale factor of `0.0001` m and zero offsets to match the Mandeye recorder. If your data is already in meters, pass `--input-unit m` to avoid additional scaling.
 
 ## Usage
 
@@ -57,6 +57,7 @@ python bag2mandeye.py mybag /tmp/out \
 - `--imu_topic`: IMU topic (default: `/livox/imu`)
 - `--chunk_len`: Chunk length in seconds (default: 20.0)
 - `--emulate_point_ts`: Interpolate timestamps for points (default: False)
+- `--input-unit`: Unit of point cloud coordinates, `mm` or `m` (default: `mm`)
 - `--lidar_sn`: Lidar serial number for `.sn` file (default: `ABC123`)
 - `--lidar_id`: Lidar id for `.sn` file (default: `0`)
 - `--absolute_imu_ts`: Use absolute IMU timestamps instead of starting at zero (default: False)


### PR DESCRIPTION
## Summary
- add `--input-unit` CLI option to choose millimeter or meter input coordinates
- scale lidar point coordinates based on selected unit when saving
- document coordinate unit selection in README

## Testing
- `python -m py_compile bag2mandeye.py`
- `python bag2mandeye.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c32d347710832a841ae0ebf594cc72